### PR TITLE
feat(backend-lib): expect lean error service in genericErrorMiddleware

### DIFF
--- a/packages/backend-lib/src/server/createDefaultApp.ts
+++ b/packages/backend-lib/src/server/createDefaultApp.ts
@@ -121,7 +121,7 @@ export async function createDefaultApp(cfg: DefaultAppCfg): Promise<BackendAppli
   // Generic error handler
   // It handles errors, returns proper status, does sentry.captureException(),
   // assigns err.data.errorId from sentry
-  app.use(genericErrorMiddleware({ sentryService, ...cfg.genericErrorMwCfg }))
+  app.use(genericErrorMiddleware({ errorService: sentryService, ...cfg.genericErrorMwCfg }))
 
   return app
 }

--- a/packages/backend-lib/src/server/createDefaultApp.ts
+++ b/packages/backend-lib/src/server/createDefaultApp.ts
@@ -121,7 +121,9 @@ export async function createDefaultApp(cfg: DefaultAppCfg): Promise<BackendAppli
   // Generic error handler
   // It handles errors, returns proper status, does sentry.captureException(),
   // assigns err.data.errorId from sentry
-  app.use(genericErrorMiddleware({ errorService: sentryService, ...cfg.genericErrorMwCfg }))
+  app.use(
+    genericErrorMiddleware({ errorReportingService: sentryService, ...cfg.genericErrorMwCfg }),
+  )
 
   return app
 }

--- a/packages/backend-lib/src/server/genericErrorMiddleware.ts
+++ b/packages/backend-lib/src/server/genericErrorMiddleware.ts
@@ -19,7 +19,6 @@ export interface GenericErrorMiddlewareCfg {
 }
 
 export interface ErrorReportingService {
-  // biome-ignore lint/suspicious/noExplicitAny: it is expected of the `captureException` to be tolerant of any argument
   captureException: (err: any) => string | undefined
 }
 
@@ -60,7 +59,6 @@ export function genericErrorMiddleware(
   }
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: the function is expected to handle any type for the `err` argument
 export function respondWithError(req: BackendRequest, res: BackendResponse, err: any): void {
   const { headersSent } = res
 


### PR DESCRIPTION
In this PR, I refactor `genericErrorMiddleware` to expect any service conforming to `ErrorReportingService` interface, rather than expect SentryService explicitly.

This is so we can use the new and shiny `errorService` in NCB3,
which will make it possible to report all caught errors to the affected users' Mixpanel trail automagically.