### PR TITLE
chore: configure biome to support monorepo

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
+  "extends": ["./packages/dev-lib/cfg/biome.jsonc"],
+  "overrides": []
+}


### PR DESCRIPTION
In this PR, I showcase the solution to the biome issues in IDEs
as described [in this thread](https://nc1.slack.com/archives/CCNTHJT7V/p1749057922617399?thread_ts=1749032277.259649&cid=CCNTHJT7V)

tl,dr: `biome` requires a config file in the root of the monorepo
by default, biome does not care about the sub folders
all overrides must be defined in the root config

Original issue: the IDE's (in this case VSCode's) biome plugin is underlining code parts that are explicitly allowed by our biome configuration.
Our biome configuration works well with `dev-lib check`, because `dev-lib` knows about our monorepo structure.
Meanwhile generic plugins do not, they rely on the CLI tool to work.
And the CLI tool relies on the root configuration.

See more: [official documentation](https://nc1.slack.com/archives/CCNTHJT7V/p1749057922617399?thread_ts=1749032277.259649&cid=CCNTHJT7V)

<img width="756" alt="Screenshot 2025-06-05 at 10 13 07" src="https://github.com/user-attachments/assets/2c825d42-19bf-4f50-b8ef-a3e447dd6e39" />

---

Upside of this approach:
- developers will not see invalid biome warnings while editing code in this repo

Downside of this approach:
- the IDE will not use separate rules (the "npm rules" and the "dev-lib" rules) separately, but all packages will use the same config
- if/when we need more per-package overrides, it must be defined in the root config (and probably in the package's own config too)