### PR TITLE
feat: add `z.dbEntity()` schema

### DIFF
--- a/packages/js-lib/src/zod/zod.shared.schemas.test.ts
+++ b/packages/js-lib/src/zod/zod.shared.schemas.test.ts
@@ -22,6 +22,50 @@ test('zod schemas with branded types should still be extensible', () => {
   expect(schema).toBeDefined()
 })
 
+describe('z.baseDBEntity', () => {
+  test('should have id, created, updated fields', () => {
+    const zodSchema = z.baseDBEntity()
+    const data = {
+      id: '123',
+      created: 1622547800,
+      updated: 1622547800,
+    }
+    const result = zodSchema.parse(data)
+    expect(result).toEqual(data)
+    expect(result.id).toBe('123')
+  })
+})
+
+describe('z.dbEntity', () => {
+  test('should have id, created, updated fields', () => {
+    const zodSchema = z.dbEntity()
+    const data = {
+      id: '123',
+      created: 1622547800,
+      updated: 1622547800,
+    }
+    const result = zodSchema.parse(data)
+    expect(result).toEqual(data)
+    expect(result.id).toBe('123')
+  })
+
+  test('should be extensible with additional fields', () => {
+    const zodSchema = z.dbEntity({
+      name: z.string(),
+    })
+    const data = {
+      id: '123',
+      created: 1622547800,
+      updated: 1622547800,
+      name: 'Test Entity',
+    }
+    const result = zodSchema.parse(data)
+    expect(result).toEqual(data)
+    expect(result.id).toBe('123')
+    expect(result.name).toBe('Test Entity')
+  })
+})
+
 describe('z.email', () => {
   test('should accept a valid email address', () => {
     const email = 'test@example.com'

--- a/packages/js-lib/src/zod/zod.shared.schemas.test.ts
+++ b/packages/js-lib/src/zod/zod.shared.schemas.test.ts
@@ -22,20 +22,6 @@ test('zod schemas with branded types should still be extensible', () => {
   expect(schema).toBeDefined()
 })
 
-describe('z.baseDBEntity', () => {
-  test('should have id, created, updated fields', () => {
-    const zodSchema = z.baseDBEntity()
-    const data = {
-      id: '123',
-      created: 1622547800,
-      updated: 1622547800,
-    }
-    const result = zodSchema.parse(data)
-    expect(result).toEqual(data)
-    expect(result.id).toBe('123')
-  })
-})
-
 describe('z.dbEntity', () => {
   test('should have id, created, updated fields', () => {
     const zodSchema = z.dbEntity()

--- a/packages/js-lib/src/zod/zod.shared.schemas.ts
+++ b/packages/js-lib/src/zod/zod.shared.schemas.ts
@@ -1,7 +1,6 @@
-import type { ZodObject, ZodString } from 'zod'
+import type { ZodString } from 'zod'
 import { z } from 'zod'
-import type { $ZodLooseShape, $ZodShape, SomeType, util } from 'zod/v4/core'
-import type { BaseDBEntity, IsoDate, UnixTimestamp, UnixTimestampMillis } from '../types.js'
+import type { IsoDate, UnixTimestamp, UnixTimestampMillis } from '../types.js'
 
 type ZodBranded<T, B> = T & Record<'_zod', Record<'output', number & B>>
 export type ZodBrandedString<B> = ZodBranded<z.ZodString, B>
@@ -109,7 +108,7 @@ type BaseDBEntityZodShape = {
   updated: ZodBrandedInt<UnixTimestamp>
 }
 
-function zDBEntity<T extends z.ZodRawShape>(): z.ZodObject<BaseDBEntityZodShape>
+function zDBEntity(): z.ZodObject<BaseDBEntityZodShape>
 function zDBEntity<T extends z.ZodRawShape>(shape: T): z.ZodObject<BaseDBEntityZodShape & T>
 
 function zDBEntity<T extends z.ZodRawShape>(shape?: T): z.ZodObject<BaseDBEntityZodShape & T> {

--- a/packages/js-lib/src/zod/zod.shared.schemas.ts
+++ b/packages/js-lib/src/zod/zod.shared.schemas.ts
@@ -1,5 +1,7 @@
+import type { ZodObject, ZodString } from 'zod'
 import { z } from 'zod'
-import type { IsoDate, UnixTimestamp, UnixTimestampMillis } from '../types.js'
+import type { $ZodLooseShape, $ZodShape, SomeType, util } from 'zod/v4/core'
+import type { BaseDBEntity, IsoDate, UnixTimestamp, UnixTimestampMillis } from '../types.js'
 
 type ZodBranded<T, B> = T & Record<'_zod', Record<'output', number & B>>
 export type ZodBrandedString<B> = ZodBranded<z.ZodString, B>
@@ -88,10 +90,38 @@ export const zIanaTimezone = (): z.ZodEnum =>
     // UTC is added to assist unit-testing, which uses UTC by default (not technically a valid Iana timezone identifier)
     .enum([...Intl.supportedValuesOf('timeZone'), 'UTC'])
 
+export const zBaseDBEntity = (): z.ZodObject<{
+  id: ZodString
+  created: ZodBrandedInt<UnixTimestamp>
+  updated: ZodBrandedInt<UnixTimestamp>
+}> => {
+  return z.object({
+    id: z.string(),
+    created: zUnixTimestamp2000(),
+    updated: zUnixTimestamp2000(),
+  })
+}
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type BaseDBEntityZodShape = {
+  id: ZodString
+  created: ZodBrandedInt<UnixTimestamp>
+  updated: ZodBrandedInt<UnixTimestamp>
+}
+
+function zDBEntity<T extends z.ZodRawShape>(): z.ZodObject<BaseDBEntityZodShape>
+function zDBEntity<T extends z.ZodRawShape>(shape: T): z.ZodObject<BaseDBEntityZodShape & T>
+
+function zDBEntity<T extends z.ZodRawShape>(shape?: T): z.ZodObject<BaseDBEntityZodShape & T> {
+  return zBaseDBEntity().extend(shape ?? {}) as z.ZodObject<BaseDBEntityZodShape & T>
+}
+
 export const customZodSchemas = {
   base62: zBase62,
   base64: zBase64,
   base64Url: zBase64Url,
+  baseDBEntity: zBaseDBEntity,
+  dbEntity: zDBEntity,
   email: zEmail,
   ianaTimezone: zIanaTimezone,
   isoDate: zIsoDate,

--- a/packages/js-lib/src/zod/zod.shared.schemas.ts
+++ b/packages/js-lib/src/zod/zod.shared.schemas.ts
@@ -119,7 +119,6 @@ export const customZodSchemas = {
   base62: zBase62,
   base64: zBase64,
   base64Url: zBase64Url,
-  baseDBEntity: zBaseDBEntity,
   dbEntity: zDBEntity,
   email: zEmail,
   ianaTimezone: zIanaTimezone,


### PR DESCRIPTION
That was not easy. 
Experienced many "give up and cry" moments.

Zod was created to be really good at producing types via `z.infer`, and not that good to be "taking types", but finally managed this without any big lies.
