### PR TITLE
chore: clean up zod schemas

### DIFF
--- a/packages/js-lib/src/string/regex.test.ts
+++ b/packages/js-lib/src/string/regex.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { zEmail } from '../zod/zod.shared.schemas.js'
+import { z } from '../zod/customZod.js'
 import { zIsValid } from '../zod/zod.util.js'
 import { SIMPLE_EMAIL_REGEX } from './regex.js'
 
@@ -8,7 +8,7 @@ test.each(['a@b.cc', 'kirill@naturalcycles.com', 'kirill@naturalcycles.co.uk'])(
   s => {
     expect(s).toMatch(SIMPLE_EMAIL_REGEX)
     // cross-check with Zod
-    expect(zIsValid(s, zEmail())).toBe(true)
+    expect(zIsValid(s, z.email())).toBe(true)
   },
 )
 
@@ -22,5 +22,5 @@ test.each([
 ])('email invalid %', s => {
   expect(s).not.toMatch(SIMPLE_EMAIL_REGEX)
   // cross-check with Zod
-  expect(zIsValid(s, zEmail())).toBe(false)
+  expect(zIsValid(s, z.email())).toBe(false)
 })

--- a/packages/js-lib/src/zod/zod.shared.schemas.ts
+++ b/packages/js-lib/src/zod/zod.shared.schemas.ts
@@ -7,99 +7,110 @@ export type ZodBrandedString<B> = ZodBranded<z.ZodString, B>
 export type ZodBrandedInt<B> = ZodBranded<z.ZodInt, B>
 export type ZodBrandedNumber<B> = ZodBranded<z.ZodNumber, B>
 
-export const TS_2500 = 16725225600 // 2500-01-01
-export const TS_2000 = 946684800 // 2000-01-01
+const TS_2500 = 16725225600 // 2500-01-01
+const TS_2000 = 946684800 // 2000-01-01
 
-export const zUnixTimestamp = (): ZodBrandedInt<UnixTimestamp> =>
-  z
+function unixTimestamp(): ZodBrandedInt<UnixTimestamp> {
+  return z
     .number()
     .int()
     .min(0)
     .max(TS_2500, 'Must be a UnixTimestamp number')
     .describe('UnixTimestamp') as ZodBrandedInt<UnixTimestamp>
+}
 
-export const zUnixTimestamp2000 = (): ZodBrandedInt<UnixTimestamp> =>
-  z
+function unixTimestamp2000(): ZodBrandedInt<UnixTimestamp> {
+  return z
     .number()
     .int()
     .min(TS_2000)
     .max(TS_2500, 'Must be a UnixTimestamp number after 2000-01-01')
     .describe('UnixTimestamp2000') as ZodBrandedInt<UnixTimestamp>
+}
 
-export const zUnixTimestampMillis = (): ZodBranded<z.ZodNumber, UnixTimestampMillis> =>
-  z
+function unixTimestampMillis(): ZodBranded<z.ZodNumber, UnixTimestampMillis> {
+  return z
     .number()
     .int()
     .min(0)
     .max(TS_2500 * 1000, 'Must be a UnixTimestampMillis number')
     .describe('UnixTimestampMillis') as ZodBrandedInt<UnixTimestampMillis>
+}
 
-export const zUnixTimestampMillis2000 = (): ZodBrandedInt<UnixTimestampMillis> =>
-  z
+function unixTimestampMillis2000(): ZodBrandedInt<UnixTimestampMillis> {
+  return z
     .number()
     .int()
     .min(TS_2000 * 1000)
     .max(TS_2500 * 1000, 'Must be a UnixTimestampMillis number after 2000-01-01')
     .describe('UnixTimestampMillis2000') as ZodBrandedInt<UnixTimestampMillis>
+}
 
-export const zSemVer = (): z.ZodString =>
-  z
+function semVer(): z.ZodString {
+  return z
     .string()
     .regex(/^[0-9]+\.[0-9]+\.[0-9]+$/, 'Must be a SemVer string')
     .describe('SemVer')
+}
 
-export const zIsoDate = (): ZodBrandedString<IsoDate> =>
-  z
+function isoDate(): ZodBrandedString<IsoDate> {
+  return z
     .string()
     .refine(v => {
       return /^\d{4}-\d{2}-\d{2}$/.test(v)
     }, 'Must be an IsoDateString')
     .describe('IsoDateString') as ZodBrandedString<IsoDate>
+}
 
-export const zEmail = (): z.ZodEmail => z.email().describe('Email')
+function email(): z.ZodEmail {
+  return z.email().describe('Email')
+}
 
-export const BASE62_REGEX = /^[a-zA-Z0-9]+$/
-export const BASE64_REGEX = /^[A-Za-z0-9+/]+={0,2}$/
-export const BASE64URL_REGEX = /^[\w\-/]+$/
+const BASE62_REGEX = /^[a-zA-Z0-9]+$/
+const BASE64_REGEX = /^[A-Za-z0-9+/]+={0,2}$/
+const BASE64URL_REGEX = /^[\w\-/]+$/
 
-export const zBase62 = (): z.ZodString =>
-  z.string().regex(BASE62_REGEX, 'Must be a base62 string').describe('Base62String')
+function base62(): z.ZodString {
+  return z.string().regex(BASE62_REGEX, 'Must be a base62 string').describe('Base62String')
+}
 
-export const zBase64 = (): z.ZodString =>
-  z.string().regex(BASE64_REGEX, 'Must be a base64 string').describe('Base64String')
+function base64(): z.ZodString {
+  return z.string().regex(BASE64_REGEX, 'Must be a base64 string').describe('Base64String')
+}
 
-export const zBase64Url = (): z.ZodString =>
-  z.string().regex(BASE64URL_REGEX, 'Must be a base64url string').describe('Base64UrlString')
+function base64Url(): z.ZodString {
+  return z.string().regex(BASE64URL_REGEX, 'Must be a base64url string').describe('Base64UrlString')
+}
 
-export const JWT_REGEX = /^[\w-]+\.[\w-]+\.[\w-]+$/
-export const zJwt = (): z.ZodString =>
-  z.string().regex(JWT_REGEX, 'Must be a JWT string').describe('JWTString')
+const JWT_REGEX = /^[\w-]+\.[\w-]+\.[\w-]+$/
+
+function jwt(): z.ZodString {
+  return z.string().regex(JWT_REGEX, 'Must be a JWT string').describe('JWTString')
+}
 
 /**
  * "Slug" - a valid URL, filename, etc.
  */
-export const zSlug = (): z.ZodString =>
-  z
+function slug(): z.ZodString {
+  return z
     .string()
     .regex(/^[a-z0-9-]{1,255}$/, 'Must be a slug string')
     .describe('Slug')
-
-export const zIanaTimezone = (): z.ZodEnum =>
-  z
-    // UTC is added to assist unit-testing, which uses UTC by default (not technically a valid Iana timezone identifier)
-    .enum([...Intl.supportedValuesOf('timeZone'), 'UTC'])
-
-export const zBaseDBEntity = (): z.ZodObject<{
-  id: ZodString
-  created: ZodBrandedInt<UnixTimestamp>
-  updated: ZodBrandedInt<UnixTimestamp>
-}> => {
-  return z.object({
-    id: z.string(),
-    created: zUnixTimestamp2000(),
-    updated: zUnixTimestamp2000(),
-  })
 }
+
+function ianaTimezone(): z.ZodEnum {
+  return (
+    z
+      // UTC is added to assist unit-testing, which uses UTC by default (not technically a valid Iana timezone identifier)
+      .enum([...Intl.supportedValuesOf('timeZone'), 'UTC'])
+  )
+}
+
+const baseDBEntitySchema = z.object({
+  id: z.string(),
+  created: unixTimestamp2000(),
+  updated: unixTimestamp2000(),
+})
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type BaseDBEntityZodShape = {
@@ -108,26 +119,26 @@ type BaseDBEntityZodShape = {
   updated: ZodBrandedInt<UnixTimestamp>
 }
 
-function zDBEntity(): z.ZodObject<BaseDBEntityZodShape>
-function zDBEntity<T extends z.ZodRawShape>(shape: T): z.ZodObject<BaseDBEntityZodShape & T>
+function dbEntity(): z.ZodObject<BaseDBEntityZodShape>
+function dbEntity<T extends z.ZodRawShape>(shape: T): z.ZodObject<BaseDBEntityZodShape & T>
 
-function zDBEntity<T extends z.ZodRawShape>(shape?: T): z.ZodObject<BaseDBEntityZodShape & T> {
-  return zBaseDBEntity().extend(shape ?? {}) as z.ZodObject<BaseDBEntityZodShape & T>
+function dbEntity<T extends z.ZodRawShape>(shape?: T): z.ZodObject<BaseDBEntityZodShape & T> {
+  return baseDBEntitySchema.extend(shape ?? {}) as z.ZodObject<BaseDBEntityZodShape & T>
 }
 
 export const customZodSchemas = {
-  base62: zBase62,
-  base64: zBase64,
-  base64Url: zBase64Url,
-  dbEntity: zDBEntity,
-  email: zEmail,
-  ianaTimezone: zIanaTimezone,
-  isoDate: zIsoDate,
-  jwt: zJwt,
-  slug: zSlug,
-  semver: zSemVer,
-  unixTimestamp: zUnixTimestamp,
-  unixTimestamp2000: zUnixTimestamp2000,
-  unixTimestampMillis: zUnixTimestampMillis,
-  unixTimestampMillis2000: zUnixTimestampMillis2000,
+  base62,
+  base64,
+  base64Url,
+  dbEntity,
+  email,
+  ianaTimezone,
+  isoDate,
+  jwt,
+  slug,
+  semver: semVer,
+  unixTimestamp,
+  unixTimestamp2000,
+  unixTimestampMillis,
+  unixTimestampMillis2000,
 }


### PR DESCRIPTION
In this PR, I clean up the zod schemas:

- remove export from schemas that are supposed to be used via `z.` API
- remove `z` prefix from schema names to simplify
- convert all const arrow functions to named functions