### PR TITLE
fix: not skip validation when `dao.bmSchema` is missing but `dao.validateBM` is defined

### DIFF
--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -1227,7 +1227,7 @@ export class CommonDao<BM extends BaseDBEntity, DBM extends BaseDBEntity = BM, I
 
     // Return as is if no schema is passed or if `skipConversion` is set
     if (
-      !schema ||
+      (!schema && !this.cfg.validateBM) ||
       opt.skipValidation ||
       (op === 'load' && !this.cfg.validateOnLoad) ||
       (op === 'save' && !this.cfg.validateOnSave)


### PR DESCRIPTION
- [x] Squash on green

That was painful to debug.

The `validateAndConvert` function takes `bmSchema` and when the schema is missing (i.e. not defined on Dao), it shortcuts the logic and returns the object as-is.

BUT with the introduction of `validateBM` super-amazing function, this check is not valid anymore.
Hence the fix.

---

Smell: 
we pass `bmSchema` to the `validateAndConvert` function but it accesses `validateBM` via `this.cfg`
BUT
- I didn't want to add a 5th argument for passing`validateBM`
- nor did I want to refactor all calls to access `this.cfg.schema` directly <- I would pick this, though.
