### PR TITLE
feat: use `IANATimezone` brand in zod

### DIFF
--- a/packages/js-lib/src/zod/zod.shared.schemas.ts
+++ b/packages/js-lib/src/zod/zod.shared.schemas.ts
@@ -1,6 +1,6 @@
 import type { ZodString } from 'zod'
 import { z } from 'zod'
-import type { IsoDate, UnixTimestamp, UnixTimestampMillis } from '../types.js'
+import type { IANATimezone, IsoDate, UnixTimestamp, UnixTimestampMillis } from '../types.js'
 
 type ZodBranded<T, B> = T & Record<'_zod', Record<'output', number & B>>
 export type ZodBrandedString<B> = ZodBranded<z.ZodString, B>
@@ -98,11 +98,12 @@ function slug(): z.ZodString {
     .describe('Slug')
 }
 
-function ianaTimezone(): z.ZodEnum {
+function ianaTimezone(): ZodBrandedString<IANATimezone> {
   return (
     z
       // UTC is added to assist unit-testing, which uses UTC by default (not technically a valid Iana timezone identifier)
       .enum([...Intl.supportedValuesOf('timeZone'), 'UTC'])
+      .describe('IANATimezone') as unknown as ZodBrandedString<IANATimezone>
   )
 }
 


### PR DESCRIPTION
In this PR, I configure `z.ianaTimezone()` to be the corresponding branded type.