### PR TITLE
fix: red parserOptions.project line in VSC

### DIFF
--- a/packages/dev-lib/cfg/eslint.config.js
+++ b/packages/dev-lib/cfg/eslint.config.js
@@ -94,7 +94,6 @@ function getConfig() {
       },
       // parser: tseslint.parser,
       parserOptions: {
-        project: 'tsconfig.json',
         parser: tseslint.parser,
         extraFileExtensions: ['.vue', '.html'],
       },


### PR DESCRIPTION
as I understand it, this line was meant to work around a now-fixed bug in typescript-eslint.
Removing it seems to resolve a relatively new issue of eslint attempting to use the wrong tsconfig.json (at least in VSC, but also maybe outside of it)