### PR TITLE
feat: cache AjvSchema in ZodSchema

### DIFF
--- a/packages/backend-lib/src/validation/ajv/ajvValidateRequest.ts
+++ b/packages/backend-lib/src/validation/ajv/ajvValidateRequest.ts
@@ -1,12 +1,13 @@
 import { _deepCopy } from '@naturalcycles/js-lib/object'
-import type { AjvSchema, AjvValidationError } from '@naturalcycles/nodejs-lib/ajv'
+import type { ZodType } from '@naturalcycles/js-lib/zod'
+import { AjvSchema, type AjvValidationError } from '@naturalcycles/nodejs-lib/ajv'
 import type { BackendRequest } from '../../server/server.model.js'
 import { handleValidationError, type ReqValidationOptions } from '../validateRequest.util.js'
 
 class AjvValidateRequest {
   body<T>(
     req: BackendRequest,
-    schema: AjvSchema<T>,
+    schema: AjvSchema<T> | ZodType<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     return this.validate(req, 'body', schema, opt)
@@ -14,7 +15,7 @@ class AjvValidateRequest {
 
   query<T>(
     req: BackendRequest,
-    schema: AjvSchema<T>,
+    schema: AjvSchema<T> | ZodType<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     return this.validate(req, 'query', schema, opt)
@@ -22,7 +23,7 @@ class AjvValidateRequest {
 
   params<T>(
     req: BackendRequest,
-    schema: AjvSchema<T>,
+    schema: AjvSchema<T> | ZodType<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     return this.validate(req, 'params', schema, opt)
@@ -50,12 +51,13 @@ class AjvValidateRequest {
   private validate<T>(
     req: BackendRequest,
     reqProperty: 'body' | 'params' | 'query' | 'headers',
-    schema: AjvSchema<T>,
+    schema: AjvSchema<T> | ZodType<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     const input: T = req[reqProperty] || {}
+    const ajvSchema = AjvSchema.create(schema)
 
-    const [error, output] = schema.getValidationResult(input, {
+    const [error, output] = ajvSchema.getValidationResult(input, {
       inputName: `request ${reqProperty}`,
     })
 

--- a/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
+++ b/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
@@ -8,7 +8,6 @@ import type { JsonSchema, JsonSchemaBuilder } from '@naturalcycles/js-lib/json-s
 import { JsonSchemaAnyBuilder } from '@naturalcycles/js-lib/json-schema'
 import { _deepCopy, _filterNullishValues } from '@naturalcycles/js-lib/object'
 import { _substringBefore } from '@naturalcycles/js-lib/string'
-import { _typeCast } from '@naturalcycles/js-lib/types'
 import { z, ZodType } from '@naturalcycles/js-lib/zod'
 import type { Ajv } from 'ajv'
 import { _inspect } from '../../string/inspect.js'


### PR DESCRIPTION
In this PR, I add a controversial change of hiding compiled AjvSchema in ZodSchemas, that way we can:
- allow developers to keep using Zod's nice API
- but still use the speed offered by Ajv.