### PR TITLE
fix: fix zod custom isoDate check

### DIFF
--- a/packages/js-lib/src/zod/zod.shared.schemas.ts
+++ b/packages/js-lib/src/zod/zod.shared.schemas.ts
@@ -6,6 +6,7 @@ type ZodBranded<T, B> = T & Record<'_zod', Record<'output', B>>
 export type ZodBrandedString<B> = ZodBranded<z.ZodString, B>
 export type ZodBrandedInt<B> = ZodBranded<z.ZodInt, B>
 export type ZodBrandedNumber<B> = ZodBranded<z.ZodNumber, B>
+export type ZodBrandedIsoDate = ZodBranded<z.ZodISODate, IsoDate>
 
 const TS_2500 = 16725225600 // 2500-01-01
 const TS_2000 = 946684800 // 2000-01-01
@@ -56,9 +57,7 @@ function semVer(): z.ZodString {
 function isoDate(): ZodBrandedString<IsoDate> {
   return z
     .string()
-    .refine(v => {
-      return /^\d{4}-\d{2}-\d{2}$/.test(v)
-    }, 'Must be a YYYY-MM-DD string')
+    .regex(/^\d{4}-\d{2}-\d{2}$/, { error: 'Must be a YYYY-MM-DD string' })
     .describe('IsoDate') as ZodBrandedString<IsoDate>
 }
 


### PR DESCRIPTION
In this PR, I fix an issue with the Zod->JsonSchema->Ajv validation pipeline regarding the validation of IsoDate properties.

The `refine` method I used to validate the IsoDate is lost in translation, but for some reason zod does not throw for that specific function. But I should have known. No idea why I chose this esoteric solution rather than a simple regex.

I extended the tests to run the validations with Ajv as well, to ensure that our custom functions work well there too.