### PR TITLE
feat: add new `j` schemas

### DIFF
--- a/packages/js-lib/src/json-schema/__snapshots__/jsonSchemaBuilder.test.ts.snap
+++ b/packages/js-lib/src/json-schema/__snapshots__/jsonSchemaBuilder.test.ts.snap
@@ -30,7 +30,7 @@ exports[`addressBMJsonSchema 1`] = `
     },
     "createdDate": {
       "description": "IsoDate",
-      "format": "date",
+      "format": "isoDate",
       "type": "string",
     },
     "id": {
@@ -93,7 +93,7 @@ exports[`addressSchema 1`] = `
     },
     "createdDate": {
       "description": "IsoDate",
-      "format": "date",
+      "format": "isoDate",
       "type": "string",
     },
     "phone": {

--- a/packages/js-lib/src/json-schema/__snapshots__/jsonSchemaBuilder.test.ts.snap
+++ b/packages/js-lib/src/json-schema/__snapshots__/jsonSchemaBuilder.test.ts.snap
@@ -30,7 +30,7 @@ exports[`addressBMJsonSchema 1`] = `
     },
     "createdDate": {
       "description": "IsoDate",
-      "format": "isoDate",
+      "format": "IsoDate",
       "type": "string",
     },
     "id": {
@@ -93,7 +93,7 @@ exports[`addressSchema 1`] = `
     },
     "createdDate": {
       "description": "IsoDate",
-      "format": "isoDate",
+      "format": "IsoDate",
       "type": "string",
     },
     "phone": {

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
@@ -300,10 +300,6 @@ describe('string', () => {
       '2001-01-01T01:01:01Z',
       '2001-01-01T01:01:01+14:00',
       '2001-01-01T01:01:01-12:00',
-      '2001-01-01T01:01:01.001',
-      '2001-01-01T01:01:01.001Z',
-      '2001-01-01T01:01:01.001+14:00',
-      '2001-01-01T01:01:01.001-12:00',
       '2000-02-29T01:01:01',
     ]
     const t = localTime.fromIsoDateTimeString('2001-01-01T01:01:01Z' as IsoDateTime)
@@ -323,6 +319,11 @@ describe('string', () => {
     const invalidCases = [
       'abcd',
       '20250930T070629Z', // valid ISO6801 but we don't support it
+      '2001-01-01T01:01:01.001', // valid ISO6801 but we don't support it
+      '2001-01-01T01:01:01.001', // valid ISO6801 but we don't support it
+      '2001-01-01T01:01:01.001Z', // valid ISO6801 but we don't support it
+      '2001-01-01T01:01:01.001+14:00', // valid ISO6801 but we don't support it
+      '2001-01-01T01:01:01.001-12:00', // valid ISO6801 but we don't support it
       '20010-01-01T01:01:01', // 5 digit year
       '2001-13-01T01:01:01', // invalid month
       '2001-01-32T01:01:01', // invalid day

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
@@ -201,6 +201,30 @@ describe('string', () => {
     })
   })
 
+  describe('regex', () => {
+    test('should accept RegExp and use it as "pattern"', () => {
+      const schema = j.object({
+        foo: j.string().regex(/^\d{1,2}$/),
+      })
+      const ajvSchema = AjvSchema.create(schema.build())
+
+      const [err1] = ajvSchema.getValidationResult({
+        foo: 'bingbong' as any,
+      })
+      expect(err1).not.toBeNull()
+
+      const [err2] = ajvSchema.getValidationResult({
+        foo: '1' as any,
+      })
+      expect(err2).toBeNull()
+
+      const [err3] = ajvSchema.getValidationResult({
+        foo: '12' as any,
+      })
+      expect(err3).toBeNull()
+    })
+  })
+
   describe('isoDate', () => {
     const schema = j.object({
       foo: j.string().isoDate(),

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
@@ -256,6 +256,11 @@ describe('string', () => {
     })
 
     const invalidCases = [
+      'abcd',
+      '0-0-0',
+      '20250930', // valid ISO6801 but we don't support it
+      '2025-W40-2', // valid ISO6801 but we don't support it
+      '2025‐273', // valid ISO6801 but we don't support it
       '20010-01-01', // 5 digit year
       '2001-13-01', // invalid month
       '2001-01-32', // invalid day
@@ -316,6 +321,8 @@ describe('string', () => {
     })
 
     const invalidCases = [
+      'abcd',
+      '20250930T070629Z', // valid ISO6801 but we don't support it
       '20010-01-01T01:01:01', // 5 digit year
       '2001-13-01T01:01:01', // invalid month
       '2001-01-32T01:01:01', // invalid day

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
@@ -347,6 +347,60 @@ describe('object', () => {
       result satisfies { id: string; created: UnixTimestamp; updated: UnixTimestamp; foo: number[] }
     })
   })
+
+  describe('additionalProps', () => {
+    test('should not remove unspecified properties when set to `true`', () => {
+      const schema = j.object({ foo: j.array(j.number()) }).additionalProps(true)
+
+      const [err, result] = AjvSchema.create(schema.build()).getValidationResult({
+        foo: [1, 2, 3],
+        // @ts-expect-error
+        bar: 'keep me',
+      })
+
+      expect(err).toBeNull()
+      // oxlint-disable-next-line no-unused-expressions
+      result satisfies { foo: number[] }
+      expect(result).toEqual({
+        foo: [1, 2, 3],
+        bar: 'keep me',
+      })
+    })
+
+    test('should remove unspecified properties when set to `false`', () => {
+      const schema = j.object({ foo: j.array(j.number()) }).additionalProps(false)
+
+      const [err, result] = AjvSchema.create(schema.build()).getValidationResult({
+        foo: [1, 2, 3],
+        // @ts-expect-error
+        bar: 'keep me',
+      })
+
+      expect(err).toBeNull()
+      // oxlint-disable-next-line no-unused-expressions
+      result satisfies { foo: number[] }
+      expect(result).toEqual({
+        foo: [1, 2, 3],
+      })
+    })
+
+    test('should remove unspecified properties when not set', () => {
+      const schema = j.object({ foo: j.array(j.number()) })
+
+      const [err, result] = AjvSchema.create(schema.build()).getValidationResult({
+        foo: [1, 2, 3],
+        // @ts-expect-error
+        bar: 'keep me',
+      })
+
+      expect(err).toBeNull()
+      // oxlint-disable-next-line no-unused-expressions
+      result satisfies { foo: number[] }
+      expect(result).toEqual({
+        foo: [1, 2, 3],
+      })
+    })
+  })
 })
 
 describe('array', () => {

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
@@ -1,5 +1,7 @@
 import { AjvSchema } from '@naturalcycles/nodejs-lib/ajv'
 import { describe, expect, expectTypeOf, test } from 'vitest'
+import { localDate } from '../datetime/localDate.js'
+import { localTime } from '../datetime/localTime.js'
 import { _stringify } from '../string/stringify.js'
 import type { BaseDBEntity, Branded, IsoDate, IsoDateTime, UnixTimestamp } from '../types.js'
 import { z } from '../zod/index.js'
@@ -238,7 +240,12 @@ describe('string', () => {
       expectTypeOf(result).toEqualTypeOf<{ foo: IsoDate }>()
     })
 
-    const validCases = ['2001-01-01', '1984-02-29', '2026-08-08']
+    const validCases = ['2001-01-01', '1984-02-29', '2026-08-08', '2000-02-29']
+    const d = localDate.fromString('2001-01-01' as IsoDate)
+    for (let i = 1; i < 366; ++i) {
+      validCases.push(d.plusDays(i).toISODate())
+    }
+
     test.each(validCases)('should accept valid case: %s', input => {
       const [err, result] = ajvSchema.getValidationResult({
         foo: input as any,
@@ -258,6 +265,7 @@ describe('string', () => {
       '2001-06-31', // invalid day for 30 day month
       '2001-09-31', // invalid day for 30 day month
       '2001-11-31', // invalid day for 30 day month
+      '2100-02-29', // not leap year b/c div. by 100 but not div. by 400
     ]
     test.each(invalidCases)('should reject invalid case: %s', input => {
       const [err, result] = ajvSchema.getValidationResult({
@@ -291,7 +299,13 @@ describe('string', () => {
       '2001-01-01T01:01:01.001Z',
       '2001-01-01T01:01:01.001+14:00',
       '2001-01-01T01:01:01.001-12:00',
+      '2000-02-29T01:01:01',
     ]
+    const t = localTime.fromIsoDateTimeString('2001-01-01T01:01:01Z' as IsoDateTime)
+    for (let i = 1; i < 366; ++i) {
+      validCases.push(t.plusDays(i).toISODateTime())
+    }
+
     test.each(validCases)('should accept valid case: %s', input => {
       const [err, result] = ajvSchema.getValidationResult({
         foo: input as any,
@@ -321,6 +335,7 @@ describe('string', () => {
       '2001-06-31T01:01:01', // invalid day for 30 day month
       '2001-09-31T01:01:01', // invalid day for 30 day month
       '2001-11-31T01:01:01', // invalid day for 30 day month
+      '2100-02-29T01:01:01', // not leap year b/c div. by 100 but not div. by 400
     ]
     test.each(invalidCases)('should reject invalid case: %s', input => {
       const [err, result] = ajvSchema.getValidationResult({

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.ts
@@ -316,6 +316,10 @@ export class JsonSchemaStringBuilder<T extends string = string> extends JsonSche
     })
   }
 
+  regex(pattern: RegExp): this {
+    return this.pattern(pattern.source)
+  }
+
   pattern(pattern: string): this {
     Object.assign(this.schema, { pattern })
     return this

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.ts
@@ -369,7 +369,7 @@ export class JsonSchemaStringBuilder<T extends string = string> extends JsonSche
    * Accepts only the `YYYY-MM-DD` shape from all ISO 8601 variants.
    */
   isoDate(): JsonSchemaStringBuilder<IsoDate> {
-    return this.format('isoDate').branded<IsoDate>().description('IsoDate')
+    return this.format('IsoDate').branded<IsoDate>().description('IsoDate')
   }
 
   /**
@@ -377,7 +377,7 @@ export class JsonSchemaStringBuilder<T extends string = string> extends JsonSche
    * and optionally end with either a `Z` or a `+/-hh:mm` timezone part.
    */
   isoDateTime(): JsonSchemaStringBuilder<IsoDateTime> {
-    return this.format('isoDateTime').branded<IsoDateTime>().description('IsoDateTime')
+    return this.format('IsoDateTime').branded<IsoDateTime>().description('IsoDateTime')
   }
 
   private transformModify(t: 'trim' | 'toLowerCase' | 'toUpperCase', add: boolean): this {

--- a/packages/nodejs-lib/src/validation/ajv/getAjv.ts
+++ b/packages/nodejs-lib/src/validation/ajv/getAjv.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/prefer-string-starts-ends-with */
+/* eslint-disable unicorn/prefer-code-point */
 import { _lazyValue } from '@naturalcycles/js-lib'
 import type { Options } from 'ajv'
 import { Ajv } from 'ajv'
@@ -79,6 +81,8 @@ const TS_2500_MILLIS = TS_2500 * 1000
 const TS_2000 = 946684800 // 2000-01-01
 const TS_2000_MILLIS = TS_2000 * 1000
 
+const monthLengths = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
 function addCustomAjvFormats(ajv: Ajv): Ajv {
   return (
     ajv
@@ -131,5 +135,109 @@ function addCustomAjvFormats(ajv: Ajv): Ajv {
           return n >= -14 && n <= 14 && Number.isInteger(n)
         },
       })
+      .addFormat('isoDate', {
+        type: 'string',
+        validate: isoDate,
+      })
+      .addFormat('isoDateTime', {
+        type: 'string',
+        validate: isoDateTime,
+      })
   )
+}
+
+function isoDate(s: string): boolean {
+  // must be exactly "YYYY-MM-DD"
+  if (s.length !== 10) return false
+  if (s.charCodeAt(4) !== 45 || s.charCodeAt(7) !== 45) return false // '-'
+
+  // fast parse numbers without substrings/Number()
+  const year =
+    (s.charCodeAt(0) - 48) * 1000 +
+    (s.charCodeAt(1) - 48) * 100 +
+    (s.charCodeAt(2) - 48) * 10 +
+    (s.charCodeAt(3) - 48)
+
+  const month = (s.charCodeAt(5) - 48) * 10 + (s.charCodeAt(6) - 48)
+  const day = (s.charCodeAt(8) - 48) * 10 + (s.charCodeAt(9) - 48)
+
+  if (month < 1 || month > 12 || day < 1) return false
+
+  if (month !== 2) {
+    return day <= monthLengths[month]!
+  }
+
+  const isLeap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0
+  return day <= (isLeap ? 29 : 28)
+}
+
+export function isoDateTime(s: string): boolean {
+  // "YYYY-MM-DDTHH:MM:SS" followed by
+  // optional ".mmm" and
+  // nothing, "Z" or "+hh:mm" or "-hh:mm"
+  if (s.length < 19 || s.length > 29) return false
+  if (s.charCodeAt(10) !== 84) return false // 'T'
+
+  const hasMsPart = s.charCodeAt(19) === 46 // '.'
+
+  const datePart = s.slice(0, 10) // YYYY-MM-DD
+  if (!isoDate(datePart)) return false
+
+  const timePart = hasMsPart ? s.slice(11, 23) : s.slice(11, 19) // HH:MM:SS.mmm
+  if (!isoTime(timePart)) return false
+
+  const zonePart = hasMsPart ? s.slice(23) : s.slice(19) // nothing or Z or +/-hh:mm
+  if (!isoTimezone(zonePart)) return false
+
+  return true
+}
+
+function isoTime(s: string): boolean {
+  // "HH:MM:SS"
+  // optional ".mmm"
+  const hasMsPart = s.charCodeAt(8) === 46 // '.'
+  const hasProperLength = (hasMsPart && s.length === 12) || (!hasMsPart && s.length === 8)
+  if (!hasProperLength) return false
+  if (s.charCodeAt(2) !== 58 || s.charCodeAt(5) !== 58) return false // ':'
+
+  const hour = (s.charCodeAt(0) - 48) * 10 + (s.charCodeAt(1) - 48)
+  if (hour < 0 || hour > 23) return false
+
+  const minute = (s.charCodeAt(3) - 48) * 10 + (s.charCodeAt(4) - 48)
+  if (minute < 0 || minute > 59) return false
+
+  const second = (s.charCodeAt(6) - 48) * 10 + (s.charCodeAt(7) - 48)
+  if (second < 0 || second > 59) return false
+
+  const ms = hasMsPart
+    ? (s.charCodeAt(9) - 48) * 100 + (s.charCodeAt(10) - 48) * 10 + (s.charCodeAt(11) - 48)
+    : 0
+  if (ms < 0 || ms > 999) return false
+
+  return true
+}
+
+function isoTimezone(s: string): boolean {
+  // "Z" or "+hh:mm" or "-hh:mm"
+  if (s === '') return true
+  if (s === 'Z') return true
+  if (s.length !== 6) return false
+  if (s.charCodeAt(0) !== 43 && s.charCodeAt(0) !== 45) return false // + or -
+  if (s.charCodeAt(3) !== 58) return false // :
+
+  const isWestern = s[0] === '-'
+  const isEastern = s[0] === '+'
+
+  const hour = (s.charCodeAt(1) - 48) * 10 + (s.charCodeAt(2) - 48)
+  if (hour < 0) return false
+  if (isWestern && hour > 12) return false
+  if (isEastern && hour > 14) return false
+
+  const minute = (s.charCodeAt(4) - 48) * 10 + (s.charCodeAt(5) - 48)
+  if (minute < 0 || minute > 59) return false
+
+  if (isEastern && hour === 14 && minute > 0) return false // max is +14:00
+  if (isWestern && hour === 12 && minute > 0) return false // min is -12:00
+
+  return true
 }


### PR DESCRIPTION
In this PR, I added/refactored:
- `j.isoDate()`
- `j.isoDateTime()`
- `j.dbEntity()`
- `j.string().regex()`

Meanwhile the jayification of `samsung.model.ts` in natsung is almost done.

Please don't hate the IsoDate(Time) checkers 😅 