### PR TITLE
feat: add `j.nullable()`

### DIFF
--- a/packages/db-lib/src/testing/test.model.ts
+++ b/packages/db-lib/src/testing/test.model.ts
@@ -58,7 +58,7 @@ export const testItemBMJsonSchema: JsonSchemaObject<TestItemBM> = j
     created: j.unixTimestamp(),
     updated: j.unixTimestamp(),
     k1: j.string(),
-    k2: j.oneOf<string | null>([j.string(), j.null()]).optional(),
+    k2: j.oneOf([j.string(), j.null()]).optional(),
     k3: j.number().optional(),
     even: j.boolean().optional(),
     b1: j.buffer().optional(),

--- a/packages/js-lib/src/json-schema/jsonSchema.model.ts
+++ b/packages/js-lib/src/json-schema/jsonSchema.model.ts
@@ -13,7 +13,7 @@ export type JsonSchema<T = unknown> =
   | JsonSchemaNumber
   | JsonSchemaBoolean
   | JsonSchemaNull
-  | JsonSchemaObject // cannot use <T>, because T needs to extend AnyObject
+  | JsonSchemaObject<T extends AnyObject ? T : AnyObject>
   | JsonSchemaArray<T>
   | JsonSchemaTuple<T>
 
@@ -28,7 +28,7 @@ export interface JsonSchemaAny<T = unknown> {
   readOnly?: boolean
   writeOnly?: boolean
 
-  type?: string
+  type?: string | string[]
 
   default?: T
 

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
@@ -8,6 +8,13 @@ import { z } from '../zod/index.js'
 import { j } from './jsonSchemaBuilder.js'
 import { baseDBEntityJsonSchema } from './jsonSchemas.js'
 
+const schema = j.object({
+  req: j.string(),
+  opt: j.string().optional(),
+})
+
+type T = (typeof schema)['infer']
+
 interface Address {
   createdAt: UnixTimestamp
   createdDate: IsoDate
@@ -502,3 +509,5 @@ describe('optional', () => {
     })
   })
 })
+
+describe('nullable', () => {})

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
@@ -8,13 +8,6 @@ import { z } from '../zod/index.js'
 import { j } from './jsonSchemaBuilder.js'
 import { baseDBEntityJsonSchema } from './jsonSchemas.js'
 
-const schema = j.object({
-  req: j.string(),
-  opt: j.string().optional(),
-})
-
-type T = (typeof schema)['infer']
-
 interface Address {
   createdAt: UnixTimestamp
   createdDate: IsoDate

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.ts
@@ -134,8 +134,11 @@ export const j = {
   },
 }
 
-export class JsonSchemaAnyBuilder<T = unknown, SCHEMA_TYPE extends JsonSchema<T> = JsonSchema<T>>
-  implements JsonSchemaBuilder<T>
+export class JsonSchemaAnyBuilder<
+  T = unknown,
+  SCHEMA_TYPE extends JsonSchema<T> = JsonSchema<T>,
+  Opt extends boolean = false,
+> implements JsonSchemaBuilder<T>
 {
   constructor(protected schema: SCHEMA_TYPE) {}
 
@@ -201,12 +204,12 @@ export class JsonSchemaAnyBuilder<T = unknown, SCHEMA_TYPE extends JsonSchema<T>
     return this
   }
 
-  optional(): JsonSchemaAnyBuilder<T | undefined, JsonSchema<T | undefined>>
-  optional(optional: true): JsonSchemaAnyBuilder<T | undefined, JsonSchema<T | undefined>>
+  optional(): JsonSchemaAnyBuilder<T | undefined, JsonSchema<T | undefined>, true>
+  optional(optional: true): JsonSchemaAnyBuilder<T | undefined, JsonSchema<T | undefined>, true>
   optional(
     optional: false,
-  ): JsonSchemaAnyBuilder<Exclude<T, undefined>, JsonSchema<Exclude<T, undefined>>>
-  optional(optional = true): JsonSchemaAnyBuilder<any, JsonSchema<any>> {
+  ): JsonSchemaAnyBuilder<Exclude<T, undefined>, JsonSchema<Exclude<T, undefined>>, false>
+  optional(optional = true): JsonSchemaAnyBuilder<any, JsonSchema<any>, false> {
     if (optional) {
       this.schema.optionalField = true
     } else {
@@ -223,8 +226,8 @@ export class JsonSchemaAnyBuilder<T = unknown, SCHEMA_TYPE extends JsonSchema<T>
     return _sortObject(JSON.parse(JSON.stringify(this.schema)), JSON_SCHEMA_ORDER)
   }
 
-  clone(): JsonSchemaAnyBuilder<T, SCHEMA_TYPE> {
-    return new JsonSchemaAnyBuilder<T, SCHEMA_TYPE>(_deepCopy(this.schema))
+  clone(): JsonSchemaAnyBuilder<T, SCHEMA_TYPE, Opt> {
+    return new JsonSchemaAnyBuilder<T, SCHEMA_TYPE, Opt>(_deepCopy(this.schema))
   }
 
   /**
@@ -233,10 +236,10 @@ export class JsonSchemaAnyBuilder<T = unknown, SCHEMA_TYPE extends JsonSchema<T>
   infer!: T
 }
 
-export class JsonSchemaNumberBuilder<T extends number = number> extends JsonSchemaAnyBuilder<
-  T,
-  JsonSchemaNumber<T>
-> {
+export class JsonSchemaNumberBuilder<
+  T extends number = number,
+  Opt extends boolean = false,
+> extends JsonSchemaAnyBuilder<T, JsonSchemaNumber<T>, Opt> {
   constructor() {
     super({
       type: 'number',
@@ -306,10 +309,10 @@ export class JsonSchemaNumberBuilder<T extends number = number> extends JsonSche
   }
 }
 
-export class JsonSchemaStringBuilder<T extends string = string> extends JsonSchemaAnyBuilder<
-  T,
-  JsonSchemaString<T>
-> {
+export class JsonSchemaStringBuilder<
+  T extends string = string,
+  Opt extends boolean = false,
+> extends JsonSchemaAnyBuilder<T, JsonSchemaString<T>, Opt> {
   constructor() {
     super({
       type: 'string',
@@ -393,10 +396,10 @@ export class JsonSchemaStringBuilder<T extends string = string> extends JsonSche
   // contentEncoding?: string
 }
 
-export class JsonSchemaObjectBuilder<T extends AnyObject> extends JsonSchemaAnyBuilder<
-  T,
-  JsonSchemaObject<T>
-> {
+export class JsonSchemaObjectBuilder<
+  T extends AnyObject,
+  Opt extends boolean = false,
+> extends JsonSchemaAnyBuilder<T, JsonSchemaObject<T>, Opt> {
   constructor() {
     super({
       type: 'object',
@@ -460,17 +463,20 @@ export class JsonSchemaObjectBuilder<T extends AnyObject> extends JsonSchemaAnyB
     return this.addRequired(['id', 'created', 'updated']) as any
   }
 
-  extend<T2 extends AnyObject>(s2: JsonSchemaObjectBuilder<T2>): JsonSchemaObjectBuilder<T & T2> {
-    const builder = new JsonSchemaObjectBuilder<T & T2>()
+  extend<T2 extends AnyObject>(
+    s2: JsonSchemaObjectBuilder<T2>,
+  ): JsonSchemaObjectBuilder<T & T2 extends infer O ? { [K in keyof O]: O[K] } : never> {
+    const builder = new JsonSchemaObjectBuilder<any>()
     Object.assign(builder.schema, _deepCopy(this.schema))
     mergeJsonSchemaObjects(builder.schema, s2.schema)
     return builder
   }
 }
 
-export class JsonSchemaArrayBuilder<ITEM> extends JsonSchemaAnyBuilder<
+export class JsonSchemaArrayBuilder<ITEM, Opt extends boolean = false> extends JsonSchemaAnyBuilder<
   ITEM[],
-  JsonSchemaArray<ITEM>
+  JsonSchemaArray<ITEM>,
+  Opt
 > {
   constructor(itemsSchema: JsonSchemaBuilder<ITEM>) {
     super({
@@ -509,16 +515,25 @@ export class JsonSchemaTupleBuilder<T extends any[]> extends JsonSchemaAnyBuilde
   }
 }
 
-// TODO and Notes
-// The issue is that in `j` we mix two approaches:
-// 1) the builder driven approach
-// 2) the type driven approach.
-
-function object<P extends Record<string, JsonSchemaAnyBuilder<any, any>>>(
+function object<P extends Record<string, JsonSchemaAnyBuilder<any, any, any>>>(
   props: P,
-): JsonSchemaObjectBuilder<{
-  [K in keyof P]: P[K] extends JsonSchemaAnyBuilder<infer U, any> ? U : never
-}>
+): JsonSchemaObjectBuilder<
+  {
+    [K in keyof P as P[K] extends JsonSchemaAnyBuilder<any, any, infer Opt>
+      ? Opt extends true
+        ? never
+        : K
+      : never]: P[K] extends JsonSchemaAnyBuilder<infer U, any, any> ? U : never
+  } & {
+    [K in keyof P as P[K] extends JsonSchemaAnyBuilder<any, any, infer Opt>
+      ? Opt extends true
+        ? K
+        : never
+      : never]?: P[K] extends JsonSchemaAnyBuilder<infer U, any, any> ? U : never
+  } extends infer O
+    ? { [K in keyof O]: O[K] }
+    : never
+>
 function object<T extends AnyObject>(props: {
   [K in keyof T]: JsonSchemaAnyBuilder<T[K]>
 }): JsonSchemaObjectBuilder<T>


### PR DESCRIPTION
In this PR, I implemented `j.nullable()` by fixing/improving `j.oneOf`.

I also improved `j.optional()` so that optional fields are inferred as `{ a?: type }` rather than `{ a: type | undefined }`.

---

`j.nullable()` is using `j.oneOf(originalSchema, j.null())` under the hood.
It's because the official way of doing this in JSONSchema caused a lot of type errors which I didn't want to fix.
The official way would be to make the `type: string` of the schema as `type: string | string[]` - for nullable numbers: `type: ["number", "null"]`.

But for that I needed to fix the type inference for `oneOf`.

And so that Skynet be merciful to me, I admit that this PR happened in close cooperation with Gepetto.