### PR TITLE
feat: improve `j.const()` add `j.jwt()`

### DIFF
--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.test.ts
@@ -2,6 +2,7 @@ import { AjvSchema } from '@naturalcycles/nodejs-lib/ajv'
 import { describe, expect, expectTypeOf, test } from 'vitest'
 import { localDate } from '../datetime/localDate.js'
 import { localTime } from '../datetime/localTime.js'
+import { _numberEnumValues } from '../enum.util.js'
 import { _stringify } from '../string/stringify.js'
 import type { BaseDBEntity, Branded, IsoDate, IsoDateTime, UnixTimestamp } from '../types.js'
 import { z } from '../zod/index.js'
@@ -577,5 +578,57 @@ describe('oneOf', () => {
     })
 
     expect(err).toBeNull()
+  })
+})
+
+describe('const', () => {
+  test('should correctly infer the type', () => {
+    enum Bar {
+      FOO = 1,
+      BAR = 2,
+    }
+    interface Foo {
+      foo: Bar.FOO
+      bar: Bar
+      n: null
+    }
+    const schema = j.object({
+      foo: j.const(Bar.FOO),
+      bar: j.enum(_numberEnumValues(Bar)),
+      n: j.const(null),
+    })
+
+    const [, result] = AjvSchema.create(schema.build()).getValidationResult({} as any)
+
+    // oxlint-disable-next-line no-unused-expressions
+    result satisfies Foo
+  })
+
+  test('should accept only the given value', () => {
+    const schema = j.object({
+      foo: j.const(1),
+      n: j.const(null),
+    })
+
+    const [err] = AjvSchema.create(schema.build()).getValidationResult({
+      foo: 1,
+      n: null,
+    } as any)
+
+    expect(err).toBeNull()
+
+    const [err1] = AjvSchema.create(schema.build()).getValidationResult({
+      foo: 2,
+      n: null,
+    } as any)
+
+    expect(err1).not.toBeNull()
+
+    const [err2] = AjvSchema.create(schema.build()).getValidationResult({
+      foo: 1,
+      n: 1,
+    } as any)
+
+    expect(err2).not.toBeNull()
   })
 })

--- a/packages/js-lib/src/json-schema/jsonSchemaBuilder.ts
+++ b/packages/js-lib/src/json-schema/jsonSchemaBuilder.ts
@@ -1,7 +1,15 @@
 import { _uniq } from '../array/array.util.js'
 import { _deepCopy } from '../object/object.util.js'
 import { _sortObject } from '../object/sortObject.js'
-import type { AnyObject, BaseDBEntity, IsoDate, IsoDateTime, UnixTimestamp } from '../types.js'
+import {
+  type AnyObject,
+  type BaseDBEntity,
+  type IsoDate,
+  type IsoDateTime,
+  JWT_REGEX,
+  type JWTString,
+  type UnixTimestamp,
+} from '../types.js'
 import { JSON_SCHEMA_ORDER } from './jsonSchema.cnst.js'
 import type {
   JsonSchema,
@@ -35,7 +43,7 @@ export const j = {
   any<T = unknown>() {
     return new JsonSchemaAnyBuilder<T, JsonSchemaAny<T>>({})
   },
-  const<T = unknown>(value: T) {
+  const<T extends string | number | boolean | null>(value: T) {
     return new JsonSchemaAnyBuilder<T, JsonSchemaConst<T>>({
       const: value,
     })
@@ -81,6 +89,9 @@ export const j = {
   // string types
   string<T extends string = string>() {
     return new JsonSchemaStringBuilder<T>()
+  },
+  jwt() {
+    return new JsonSchemaStringBuilder<JWTString>().jwt()
   },
 
   /**
@@ -382,6 +393,10 @@ export class JsonSchemaStringBuilder<
    */
   isoDateTime(): JsonSchemaStringBuilder<IsoDateTime> {
     return this.format('IsoDateTime').branded<IsoDateTime>().description('IsoDateTime')
+  }
+
+  jwt(): this {
+    return this.regex(JWT_REGEX)
   }
 
   private transformModify(t: 'trim' | 'toLowerCase' | 'toUpperCase', add: boolean): this {

--- a/packages/js-lib/src/types.ts
+++ b/packages/js-lib/src/types.ts
@@ -335,6 +335,7 @@ export type ShortBoolean = '1'
 export type Base64String = string
 export type Base64UrlString = string
 export type JWTString = string
+export const JWT_REGEX = /^[\w-]+\.[\w-]+\.[\w-]+$/
 
 export type SemVerString = string
 


### PR DESCRIPTION
In this PR, I improve `j.const()` and add `j.jwt()`.

---

Improvement of `j.const()`:

it used the base type of the value, e.g.: `j.const(SomeEnum.FOO)` got inferred as a `SomeEnum` field, rather than `SomeEnum.FOO` field - which does not satisfy stricter interfaces.