### PR TITLE
feat: cache AjvSchema and support all Ajv-compatible schemas

### DIFF
--- a/packages/backend-lib/src/validation/ajv/ajvValidateRequest.ts
+++ b/packages/backend-lib/src/validation/ajv/ajvValidateRequest.ts
@@ -1,13 +1,16 @@
 import { _deepCopy } from '@naturalcycles/js-lib/object'
-import type { ZodType } from '@naturalcycles/js-lib/zod'
-import { AjvSchema, type AjvValidationError } from '@naturalcycles/nodejs-lib/ajv'
+import {
+  AjvSchema,
+  type AjvValidationError,
+  type SchemaHandledByAjv,
+} from '@naturalcycles/nodejs-lib/ajv'
 import type { BackendRequest } from '../../server/server.model.js'
 import { handleValidationError, type ReqValidationOptions } from '../validateRequest.util.js'
 
 class AjvValidateRequest {
   body<T>(
     req: BackendRequest,
-    schema: AjvSchema<T> | ZodType<T>,
+    schema: SchemaHandledByAjv<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     return this.validate(req, 'body', schema, opt)
@@ -15,7 +18,7 @@ class AjvValidateRequest {
 
   query<T>(
     req: BackendRequest,
-    schema: AjvSchema<T> | ZodType<T>,
+    schema: SchemaHandledByAjv<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     return this.validate(req, 'query', schema, opt)
@@ -23,7 +26,7 @@ class AjvValidateRequest {
 
   params<T>(
     req: BackendRequest,
-    schema: AjvSchema<T> | ZodType<T>,
+    schema: SchemaHandledByAjv<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     return this.validate(req, 'params', schema, opt)
@@ -39,7 +42,7 @@ class AjvValidateRequest {
    */
   headers<T>(
     req: BackendRequest,
-    schema: AjvSchema<T>,
+    schema: SchemaHandledByAjv<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     const originalHeaders = _deepCopy(req.headers)
@@ -51,7 +54,7 @@ class AjvValidateRequest {
   private validate<T>(
     req: BackendRequest,
     reqProperty: 'body' | 'params' | 'query' | 'headers',
-    schema: AjvSchema<T> | ZodType<T>,
+    schema: SchemaHandledByAjv<T>,
     opt: ReqValidationOptions<AjvValidationError> = {},
   ): T {
     const input: T = req[reqProperty] || {}

--- a/packages/js-lib/src/zod/zodJsonSchema.test.ts
+++ b/packages/js-lib/src/zod/zodJsonSchema.test.ts
@@ -1,4 +1,4 @@
-import { AjvSchema } from '@naturalcycles/nodejs-lib/ajv'
+import { AjvSchema, HIDDEN_AJV_SCHEMA } from '@naturalcycles/nodejs-lib/ajv'
 import { expect, test } from 'vitest'
 import { _stringify } from '../string/stringify.js'
 import type { UnixTimestamp } from '../types.js'
@@ -78,6 +78,7 @@ test('happy case (just zod)', () => {
 })
 
 test('account json schema', () => {
+  delete (accountJsonSchema as any)[HIDDEN_AJV_SCHEMA]
   expect(accountJsonSchema).toMatchInlineSnapshot(`
     {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/nodejs-lib/src/validation/ajv/ajvSchema.test.ts
+++ b/packages/nodejs-lib/src/validation/ajv/ajvSchema.test.ts
@@ -1,8 +1,8 @@
+import { j, type JsonSchema, type JsonSchemaObjectBuilder } from '@naturalcycles/js-lib/json-schema'
 import { _typeCast } from '@naturalcycles/js-lib/types'
-import { z, ZodType } from '@naturalcycles/js-lib/zod'
+import { z, type ZodType } from '@naturalcycles/js-lib/zod'
 import { describe, expect, test } from 'vitest'
 import { AjvSchema, HIDDEN_AJV_SCHEMA, type WithCachedAjvSchema } from './ajvSchema.js'
-import { j, JsonSchemaObjectBuilder, type JsonSchema } from '@naturalcycles/js-lib/json-schema'
 
 describe('create', () => {
   test('should cache the compiled AjvSchema in the ZodSchema', () => {

--- a/packages/nodejs-lib/src/validation/ajv/ajvSchema.test.ts
+++ b/packages/nodejs-lib/src/validation/ajv/ajvSchema.test.ts
@@ -1,7 +1,38 @@
 import { _typeCast } from '@naturalcycles/js-lib/types'
-import { z } from '@naturalcycles/js-lib/zod'
+import { z, ZodType } from '@naturalcycles/js-lib/zod'
 import { describe, expect, test } from 'vitest'
-import { AjvSchema, HIDDEN_AJV_SCHEMA, type ZodTypeWithAjvSchema } from './ajvSchema.js'
+import { AjvSchema, HIDDEN_AJV_SCHEMA, type WithCachedAjvSchema } from './ajvSchema.js'
+import { j, JsonSchemaObjectBuilder, type JsonSchema } from '@naturalcycles/js-lib/json-schema'
+
+describe('create', () => {
+  test('should cache the compiled AjvSchema in the ZodSchema', () => {
+    const zodSchema = z.object({ foo: z.string() })
+
+    const ajvSchema = AjvSchema.create(zodSchema)
+
+    _typeCast<WithCachedAjvSchema<ZodType<any>, any>>(zodSchema)
+    expect(zodSchema[HIDDEN_AJV_SCHEMA]).toBe(ajvSchema)
+  })
+
+  test('should cache the compiled AjvSchema in the JsonSchemaBuilder', () => {
+    const jsonSchemaBuilder = j.object({ foo: j.string() })
+
+    const ajvSchema = AjvSchema.create(jsonSchemaBuilder)
+
+    _typeCast<WithCachedAjvSchema<JsonSchemaObjectBuilder<any>, any>>(jsonSchemaBuilder)
+    expect(jsonSchemaBuilder[HIDDEN_AJV_SCHEMA]).toBe(ajvSchema)
+  })
+
+  test('should cache the compiled AjvSchema in the JsonSchema', () => {
+    const jsonSchemaBuilder = j.object({ foo: j.string() })
+    const jsonSchema = jsonSchemaBuilder.build()
+
+    const ajvSchema = AjvSchema.create(jsonSchema)
+
+    _typeCast<WithCachedAjvSchema<JsonSchema<any>, any>>(jsonSchema)
+    expect(jsonSchema[HIDDEN_AJV_SCHEMA]).toBe(ajvSchema)
+  })
+})
 
 describe('createFromZod', () => {
   test('should cache the compiled AjvSchema inside the ZodSchema', () => {
@@ -9,7 +40,7 @@ describe('createFromZod', () => {
 
     const ajvSchema = AjvSchema.createFromZod(zodSchema)
 
-    _typeCast<ZodTypeWithAjvSchema<any>>(zodSchema)
+    _typeCast<WithCachedAjvSchema<ZodType<any>, any>>(zodSchema)
     expect(zodSchema[HIDDEN_AJV_SCHEMA]).toBe(ajvSchema)
   })
 
@@ -20,9 +51,9 @@ describe('createFromZod', () => {
 
     const ajvSchema = AjvSchema.createFromZod(zodSchema)
 
-    _typeCast<ZodTypeWithAjvSchema<any>>(zodSchema1)
+    _typeCast<WithCachedAjvSchema<ZodType<any>, any>>(zodSchema1)
     expect(zodSchema1[HIDDEN_AJV_SCHEMA]).toBe(ajvSchema1)
-    _typeCast<ZodTypeWithAjvSchema<any>>(zodSchema)
+    _typeCast<WithCachedAjvSchema<ZodType<any>, any>>(zodSchema)
     expect(zodSchema[HIDDEN_AJV_SCHEMA]).toBe(ajvSchema)
   })
 

--- a/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
+++ b/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
@@ -8,12 +8,12 @@ import type { JsonSchema, JsonSchemaBuilder } from '@naturalcycles/js-lib/json-s
 import { JsonSchemaAnyBuilder } from '@naturalcycles/js-lib/json-schema'
 import { _deepCopy, _filterNullishValues } from '@naturalcycles/js-lib/object'
 import { _substringBefore } from '@naturalcycles/js-lib/string'
+import type { AnyObject } from '@naturalcycles/js-lib/types'
 import { z, ZodType } from '@naturalcycles/js-lib/zod'
 import type { Ajv } from 'ajv'
 import { _inspect } from '../../string/inspect.js'
 import { AjvValidationError } from './ajvValidationError.js'
 import { getAjv } from './getAjv.js'
-import type { AnyObject } from '@naturalcycles/js-lib/types'
 
 export type SchemaHandledByAjv<T> = JsonSchemaBuilder<T> | JsonSchema<T> | AjvSchema<T> | ZodType<T>
 

--- a/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
+++ b/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
@@ -15,6 +15,8 @@ import { AjvValidationError } from './ajvValidationError.js'
 import { getAjv } from './getAjv.js'
 import type { AnyObject } from '@naturalcycles/js-lib/types'
 
+export type SchemaHandledByAjv<T> = JsonSchemaBuilder<T> | JsonSchema<T> | AjvSchema<T> | ZodType<T>
+
 export interface AjvValidationOptions {
   /**
    * Defaults to true,
@@ -105,10 +107,7 @@ export class AjvSchema<T = unknown> {
    * Implementation note: JsonSchemaBuilder goes first in the union type, otherwise TypeScript fails to infer <T> type
    * correctly for some reason.
    */
-  static create<T>(
-    schema: JsonSchemaBuilder<T> | JsonSchema<T> | AjvSchema<T> | ZodType<T>,
-    cfg?: Partial<AjvSchemaCfg>,
-  ): AjvSchema<T> {
+  static create<T>(schema: SchemaHandledByAjv<T>, cfg?: Partial<AjvSchemaCfg>): AjvSchema<T> {
     if (schema instanceof AjvSchema) return schema
 
     if (AjvSchema.isSchemaWithCachedAjvSchema<typeof schema, T>(schema)) {

--- a/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
+++ b/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
@@ -131,7 +131,9 @@ export class AjvSchema<T = unknown> {
   }
 
   /**
-   * @experimental
+   * @deprecated
+   *
+   * Use `AjvSchema.create`
    */
   static createFromZod<T>(zodSchema: ZodType<T>, cfg?: Partial<AjvSchemaCfg>): AjvSchema<T> {
     return AjvSchema.create(zodSchema, cfg)

--- a/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
+++ b/packages/nodejs-lib/src/validation/ajv/ajvSchema.ts
@@ -13,6 +13,7 @@ import type { Ajv } from 'ajv'
 import { _inspect } from '../../string/inspect.js'
 import { AjvValidationError } from './ajvValidationError.js'
 import { getAjv } from './getAjv.js'
+import type { AnyObject } from '@naturalcycles/js-lib/types'
 
 export interface AjvValidationOptions {
   /**
@@ -109,27 +110,40 @@ export class AjvSchema<T = unknown> {
     cfg?: Partial<AjvSchemaCfg>,
   ): AjvSchema<T> {
     if (schema instanceof AjvSchema) return schema
-    if (schema instanceof JsonSchemaAnyBuilder) {
-      return new AjvSchema<T>(schema.build(), cfg)
+
+    if (AjvSchema.isSchemaWithCachedAjvSchema<typeof schema, T>(schema)) {
+      return AjvSchema.requireCachedAjvSchema<typeof schema, T>(schema)
     }
-    if (schema instanceof ZodType) return AjvSchema.createFromZod(schema)
-    return new AjvSchema<T>(schema as JsonSchema<T>, cfg)
+
+    let jsonSchema: JsonSchema<T>
+
+    if (AjvSchema.isJsonSchemaBuilder(schema)) {
+      jsonSchema = schema.build()
+    } else if (AjvSchema.isZodSchema(schema)) {
+      jsonSchema = z.toJSONSchema(schema, { target: 'draft-7' }) as JsonSchema<T>
+    } else {
+      jsonSchema = schema
+    }
+
+    const ajvSchema = new AjvSchema<T>(jsonSchema, cfg)
+    AjvSchema.cacheAjvSchema(schema, ajvSchema)
+
+    return ajvSchema
   }
 
   /**
    * @experimental
    */
   static createFromZod<T>(zodSchema: ZodType<T>, cfg?: Partial<AjvSchemaCfg>): AjvSchema<T> {
-    if (AjvSchema.isZodSchemaWithAjvSchema(zodSchema)) {
-      return AjvSchema.requireCachedAjvSchemaFromZodSchema(zodSchema)
-    }
+    return AjvSchema.create(zodSchema, cfg)
+  }
 
-    const jsonSchema = z.toJSONSchema(zodSchema, { target: 'draft-7' })
-    const ajvSchema = new AjvSchema<T>(jsonSchema as JsonSchema<T>, cfg)
+  static isJsonSchemaBuilder<T>(schema: unknown): schema is JsonSchemaBuilder<T> {
+    return schema instanceof JsonSchemaAnyBuilder
+  }
 
-    AjvSchema.cacheAjvSchemaInZodSchema(zodSchema, ajvSchema)
-
-    return ajvSchema
+  static isZodSchema<T>(schema: unknown): schema is ZodType<T> {
+    return schema instanceof ZodType
   }
 
   readonly cfg: AjvSchemaCfg
@@ -208,19 +222,21 @@ export class AjvSchema<T = unknown> {
     }
   }
 
-  static isZodSchemaWithAjvSchema<T>(schema: ZodType<T>): schema is ZodTypeWithAjvSchema<T> {
-    return !!(schema as any)[HIDDEN_AJV_SCHEMA]
+  static isSchemaWithCachedAjvSchema<Base, T>(
+    schema: Base,
+  ): schema is WithCachedAjvSchema<Base, T> {
+    return !!(schema as any)?.[HIDDEN_AJV_SCHEMA]
   }
 
-  static cacheAjvSchemaInZodSchema<T>(
-    zodSchema: ZodType<T>,
+  static cacheAjvSchema<Base extends AnyObject, T>(
+    schema: Base,
     ajvSchema: AjvSchema<T>,
-  ): ZodTypeWithAjvSchema<T> {
-    return Object.assign(zodSchema, { [HIDDEN_AJV_SCHEMA]: ajvSchema })
+  ): WithCachedAjvSchema<Base, T> {
+    return Object.assign(schema, { [HIDDEN_AJV_SCHEMA]: ajvSchema })
   }
 
-  static requireCachedAjvSchemaFromZodSchema<T>(zodSchema: ZodTypeWithAjvSchema<T>): AjvSchema<T> {
-    return zodSchema[HIDDEN_AJV_SCHEMA]
+  static requireCachedAjvSchema<Base, T>(schema: WithCachedAjvSchema<Base, T>): AjvSchema<T> {
+    return schema[HIDDEN_AJV_SCHEMA]
   }
 
   private getAJVValidateFunction = _lazyValue(() => this.cfg.ajv.compile<T>(this.schema))
@@ -230,6 +246,6 @@ const separator = '\n'
 
 export const HIDDEN_AJV_SCHEMA = Symbol('HIDDEN_AJV_SCHEMA')
 
-export interface ZodTypeWithAjvSchema<T> extends ZodType<T> {
+export type WithCachedAjvSchema<Base, T> = Base & {
   [HIDDEN_AJV_SCHEMA]: AjvSchema<T>
 }


### PR DESCRIPTION
In this PR, I refactored how we build and cache AjvSchemas, so that not only Zod schemas get a cache.

And I extended the schema support in `ajvValidateRequest` - to support all schemas that our AjvSchema class supports.

Merging this PR should fix the failing CI for the natsung PR.