### PR TITLE
feat: incr(batch) with ttl

### DIFF
--- a/packages/redis-lib/src/redisClient.manual.test.ts
+++ b/packages/redis-lib/src/redisClient.manual.test.ts
@@ -18,6 +18,24 @@ afterAll(async () => {
   await client.disconnect()
 })
 
+describe('incr', () => {
+  test('should create a non-existing key without expiry', async () => {
+    const result = await client.incr('test:one')
+
+    expect(result).toBe(1)
+    expect(await client.ttl('test:one')).toBe(-1)
+  })
+
+  test('should preserve the expiry of an existing key', async () => {
+    await client.setWithTTL('test:one', 1, localTime.now().plusSeconds(100).unix)
+
+    const result = await client.incr('test:one')
+
+    expect(result).toBe(2)
+    expect(await client.ttl('test:one')).toBeGreaterThan(0)
+  })
+})
+
 test('incrBatch should increase multiple keys', async () => {
   await client.set('test:one', 1)
   await client.set('test:two', 2)
@@ -31,6 +49,57 @@ test('incrBatch should increase multiple keys', async () => {
     ['test:one', 2],
     ['test:two', 4],
   ])
+})
+
+describe('incrBatchWithTTL', () => {
+  test('should increase multiple keys and give them an expiry', async () => {
+    await client.set('test:one', 1)
+    await client.set('test:two', 2)
+
+    const result = await client.incrBatchWithTTL(
+      [
+        ['test:one', 1],
+        ['test:two', 2],
+      ],
+      localTime.now().plusSeconds(100).unix,
+    )
+
+    expect(result).toEqual([
+      ['test:one', 2],
+      ['test:two', 4],
+    ])
+    expect(await client.ttl('test:one')).toBeGreaterThan(0)
+    expect(await client.ttl('test:two')).toBeGreaterThan(0)
+  })
+})
+
+describe('incrWithTTL', () => {
+  test('should create a non-existing key with an expiry', async () => {
+    const result = await client.incrWithTTL('test:one', localTime.now().plusSeconds(100).unix)
+
+    expect(result).toBe(1)
+    expect(await client.ttl('test:one')).toBeGreaterThan(0)
+  })
+
+  test('should NOT extend the expiry of an ongoing window', async () => {
+    await client.incrWithTTL('test:one', localTime.now().plusSeconds(100).unix)
+
+    const result = await client.incrWithTTL('test:one', localTime.now().plusSeconds(10_000).unix)
+
+    expect(result).toBe(2)
+    expect(await client.ttl('test:one')).toBeLessThanOrEqual(100)
+  })
+
+  test('should restore a missing expiry', async () => {
+    // How a bare INCR on a missing key leaves it: a counter that never resets
+    await client.set('test:one', 5)
+    expect(await client.ttl('test:one')).toBe(-1)
+
+    const result = await client.incrWithTTL('test:one', localTime.now().plusSeconds(100).unix)
+
+    expect(result).toBe(6)
+    expect(await client.ttl('test:one')).toBeGreaterThan(0)
+  })
 })
 
 describe('hashmap functions', () => {

--- a/packages/redis-lib/src/redisClient.manual.test.ts
+++ b/packages/redis-lib/src/redisClient.manual.test.ts
@@ -100,6 +100,20 @@ describe('incrWithTTL', () => {
     expect(result).toBe(6)
     expect(await client.ttl('test:one')).toBeGreaterThan(0)
   })
+
+  test('should throw on an invalid expireAt, leaving a key that self-heals', async () => {
+    await expect(client.incrWithTTL('test:one', 1.5 as UnixTimestamp)).rejects.toThrow(
+      'value is not an integer or out of range',
+    )
+
+    // Redis does not roll back, so the increment stands and the key is left without an expiry
+    expect(await client.get('test:one')).toBe('1')
+    expect(await client.ttl('test:one')).toBe(-1)
+
+    // ...until the next successful call, which gives it one back
+    await client.incrWithTTL('test:one', localTime.now().plusSeconds(100).unix)
+    expect(await client.ttl('test:one')).toBeGreaterThan(0)
+  })
 })
 
 describe('hashmap functions', () => {

--- a/packages/redis-lib/src/redisClient.manual.test.ts
+++ b/packages/redis-lib/src/redisClient.manual.test.ts
@@ -71,6 +71,23 @@ describe('incrBatchWithTTL', () => {
     expect(await client.ttl('test:one')).toBeGreaterThan(0)
     expect(await client.ttl('test:two')).toBeGreaterThan(0)
   })
+
+  test('should NOT extend the expiry of an ongoing window', async () => {
+    const tuples: [string, number][] = [
+      ['test:one', 1],
+      ['test:two', 2],
+    ]
+    await client.incrBatchWithTTL(tuples, localTime.now().plusSeconds(100).unix)
+
+    const result = await client.incrBatchWithTTL(tuples, localTime.now().plusSeconds(10_000).unix)
+
+    expect(result).toEqual([
+      ['test:one', 2],
+      ['test:two', 4],
+    ])
+    expect(await client.ttl('test:one')).toBeLessThanOrEqual(100)
+    expect(await client.ttl('test:two')).toBeLessThanOrEqual(100)
+  })
 })
 
 describe('incrWithTTL', () => {

--- a/packages/redis-lib/src/redisClient.ts
+++ b/packages/redis-lib/src/redisClient.ts
@@ -1,3 +1,4 @@
+import { _assert } from '@naturalcycles/js-lib/error'
 import type { CommonLogger } from '@naturalcycles/js-lib/log'
 import type {
   AnyObject,
@@ -221,11 +222,35 @@ export class RedisClient implements CommonClient {
     await redis.mset(obj)
   }
 
+  /**
+   * For counters that are supposed to expire, use {@link incrWithTTL} instead.
+   */
   async incr(key: string, by = 1): Promise<number> {
     const redis = await this.redis()
     return await redis.incrby(key, by)
   }
 
+  /**
+   * Increments the key and guarantees it has an expiry, in a single transaction.
+   *
+   * Returns the new value.
+   *
+   * Requires Redis 7.0+
+   */
+  async incrWithTTL(key: string, expireAt: UnixTimestamp, by = 1): Promise<number> {
+    const redis = await this.redis()
+    const results = await redis.multi().incrby(key, by).expireat(key, expireAt, 'NX').exec()
+    const result = results?.[0]
+    _assert(result, `redis: incrWithTTL transaction returned no result, key: ${key}`)
+
+    const [err, value] = result
+    if (err) throw err
+    return value as number
+  }
+
+  /**
+   * For counters that are supposed to expire, use {@link incrBatchWithTTL} instead.
+   */
   async incrBatch(incrementTuples: [string, number][]): Promise<[string, number][]> {
     const results: StringMap<number | undefined> = {}
 
@@ -243,6 +268,38 @@ export class RedisClient implements CommonClient {
     ][]
 
     return validResults
+  }
+
+  /**
+   * Batch version of {@link incrWithTTL}, all increments and expiries in a single transaction.
+   *
+   * Requires Redis 7.0+
+   */
+  async incrBatchWithTTL(
+    incrementTuples: [string, number][],
+    expireAt: UnixTimestamp,
+  ): Promise<[string, number][]> {
+    const redis = await this.redis()
+    const multi = redis.multi()
+
+    for (const [key, increment] of incrementTuples) {
+      multi.incrby(key, increment)
+      multi.expireat(key, expireAt, 'NX')
+    }
+
+    // 2 commands are queued per key, so the increments sit at the even indexes
+    const results = await multi.exec()
+    const expectedLength = incrementTuples.length * 2
+    _assert(
+      results?.length === expectedLength,
+      `redis: incrBatchWithTTL expected ${expectedLength} results, got ${results?.length}`,
+    )
+
+    return incrementTuples.map(([key], i) => {
+      const [err, newValue] = results[i * 2]!
+      if (err) throw err
+      return [key, newValue as number]
+    })
   }
 
   async ttl(key: string): Promise<number> {

--- a/packages/redis-lib/src/redisClient.ts
+++ b/packages/redis-lib/src/redisClient.ts
@@ -243,8 +243,13 @@ export class RedisClient implements CommonClient {
     const result = results?.[0]
     _assert(result, `redis: incrWithTTL transaction returned no result, key: ${key}`)
 
-    const [err, value] = result
-    if (err) throw err
+    // Redis does not roll back, so a failed EXPIREAT leaves the key incremented and without an
+    // expiry. It self-heals on the next successful call, as EXPIREAT NX applies to a TTL-less key.
+    for (const [err] of results) {
+      if (err) throw err
+    }
+
+    const [, value] = result
     return value as number
   }
 
@@ -295,9 +300,12 @@ export class RedisClient implements CommonClient {
       `redis: incrBatchWithTTL expected ${expectedLength} results, got ${results?.length}`,
     )
 
-    return incrementTuples.map(([key], i) => {
-      const [err, newValue] = results[i * 2]!
+    for (const [err] of results) {
       if (err) throw err
+    }
+
+    return incrementTuples.map(([key], i) => {
+      const [, newValue] = results[i * 2]!
       return [key, newValue as number]
     })
   }


### PR DESCRIPTION
Provides a solution for this non-atomic operation:

1. Read a record
2. If it exists, increment it (maintaining the same TTL)

Previously, a non-atomic solution might have been:

1. Read a record
2. Create it if with a given TTL it doesn't exist, and return
3. Otherwise, increment it

A race condition here could have incremented a non-existent record, giving it a `-1` TTL, i.e immortality.