### PR TITLE
fix: throw when using compressed properties with functions that don't support it

### DIFF
--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -1343,4 +1343,196 @@ describe('auto compression', () => {
       expect(onOversizeWarning).not.toHaveBeenCalled()
     })
   })
+
+  describe('assertNotCompressed', () => {
+    function createDao(): CommonDao<Item> {
+      return new CommonDao<Item>({
+        table: TEST_TABLE,
+        db,
+        compress: {
+          keys: ['obj', 'shu'],
+        },
+      })
+    }
+
+    // Write APIs
+    test('patchByIds should throw on a compressed key', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.patchByIds(['id1'], { shu: 'shu1-patched' }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: patchByIds on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('patchByQuery should throw on a compressed key', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.query().patchByQuery({ obj: { objId: 'objId1' } }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: patchByQuery on TEST_TABLE cannot touch compressed property: obj]`,
+      )
+    })
+
+    test('increment should throw on a compressed key', async () => {
+      const dao = createDao()
+
+      await expect(dao.increment('shu', 'id1')).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: increment on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('incrementBatch should throw on a compressed key', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.incrementBatch('shu', { id1: 1 }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: incrementBatch on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    // Query APIs
+    test('filter on a compressed key should throw', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.query().filterEq('shu', 'shu1').runQuery(),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: filter on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('order by a compressed key should throw', async () => {
+      const dao = createDao()
+
+      await expect(dao.query().order('shu').runQuery()).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: order on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('select of a compressed key should throw', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.query().select(['shu']).runQuery(),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: select on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('select of __compressed should throw', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao
+          .query()
+          .select(['__compressed' as any])
+          .runQuery(),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: select on TEST_TABLE cannot touch compressed property: __compressed]`,
+      )
+    })
+
+    test('runQuerySingleColumn should throw on a compressed column', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.runQuerySingleColumn(dao.query().select(['shu'])),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: runQuerySingleColumn on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('runQueryCount should throw on a compressed filter', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.query().filterEq('shu', 'shu1').runQueryCount(),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: filter on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('queryIds should throw on a compressed filter', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.queryIds(dao.query().filterEq('shu', 'shu1')),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: filter on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('deleteByQuery should throw on a compressed filter', async () => {
+      const dao = createDao()
+
+      await expect(
+        dao.query().filterEq('shu', 'shu1').deleteByQuery(),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: filter on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    // Stream APIs throw synchronously, before the Pipeline is created
+    test('streamQuery should throw on a compressed select', async () => {
+      const dao = createDao()
+
+      expect(() => dao.streamQuery(dao.query().select(['shu']))).toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: select on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('streamQueryAsDBM should throw on a compressed select', async () => {
+      const dao = createDao()
+
+      expect(() =>
+        dao.streamQueryAsDBM(dao.query().select(['shu'])),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: select on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    test('streamQueryIds should throw on a compressed filter', async () => {
+      const dao = createDao()
+
+      expect(() =>
+        dao.streamQueryIds(dao.query().filterEq('shu', 'shu1')),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[AssertionError: filter on TEST_TABLE cannot touch compressed property: shu]`,
+      )
+    })
+
+    // Non-compressed properties are unaffected
+    test('should allow non-compressed properties', async () => {
+      const dao = createDao()
+      await dao.save({ id: 'id1', obj: { objId: 'objId1' }, shu: 'shu1' })
+
+      expect(await dao.query().filterEq('id', 'id1').runQueryCount()).toBe(1)
+      expect(await dao.query().order('created').runQueryCount()).toBe(1)
+      expect(await dao.query().select(['id']).runQuery()).toEqual([{ id: 'id1' }])
+      expect(await dao.patchByIds(['id1'], { updated: 12345 as UnixTimestamp })).toBe(1)
+      expect(await dao.increment('created', 'id1')).toBe(MOCK_TS_2018_06_21 + 1)
+
+      // The compressed payload is left intact
+      const { data } = dao.cfg.db as InMemoryDB
+      expect(data[TEST_TABLE]!['id1']).toMatchObject({
+        __compressed: expect.any(Buffer),
+        updated: 12345,
+      })
+    })
+
+    test('should not throw when compression is not enabled', async () => {
+      const daoWithoutCompression = new CommonDao<Item>({
+        table: TEST_TABLE,
+        db,
+      })
+      await daoWithoutCompression.save({ id: 'id1', obj: { objId: 'objId1' }, shu: 'shu1' })
+
+      expect(await daoWithoutCompression.query().filterEq('shu', 'shu1').runQueryCount()).toBe(1)
+      expect(await daoWithoutCompression.patchByIds(['id1'], { shu: 'shu1-patched' })).toBe(1)
+    })
+  })
 })

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -10,19 +10,19 @@ import {
   _pick,
 } from '@naturalcycles/js-lib/object/object.util.js'
 import { pMap } from '@naturalcycles/js-lib/promise/pMap.js'
-import {
-  _objectKeys,
-  _passthroughPredicate,
-  _stringMapEntries,
-  _stringMapValues,
-  _typeCast,
-} from '@naturalcycles/js-lib/types'
 import type {
   BaseDBEntity,
   NonNegativeInteger,
   ObjectWithId,
   StringMap,
   Unsaved,
+} from '@naturalcycles/js-lib/types'
+import {
+  _objectKeys,
+  _passthroughPredicate,
+  _stringMapEntries,
+  _stringMapValues,
+  _typeCast,
 } from '@naturalcycles/js-lib/types'
 import { stringId } from '@naturalcycles/nodejs-lib'
 import type { JsonSchema } from '@naturalcycles/nodejs-lib/ajv'
@@ -189,6 +189,7 @@ export class CommonDao<
       q._selectedFieldNames?.length === 1,
       `runQuerySingleColumn requires exactly 1 column to be selected: ${q.pretty()}`,
     )
+    this.assertNotCompressed(q._selectedFieldNames, 'runQuerySingleColumn')
 
     const col = q._selectedFieldNames[0]!
 
@@ -212,7 +213,7 @@ export class CommonDao<
     q: DBQuery<DBM>,
     opt: CommonDaoReadOptions = {},
   ): Promise<RunQueryResult<BM>> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     const { rows: rawRows, ...queryResult } = await this.cfg.db.runQuery<DBM>(q, opt)
     const isPartialQuery = !!q._selectedFieldNames
@@ -233,7 +234,7 @@ export class CommonDao<
     q: DBQuery<DBM>,
     opt: CommonDaoReadOptions = {},
   ): Promise<RunQueryResult<DBM>> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     const { rows: rawRows, ...queryResult } = await this.cfg.db.runQuery<DBM>(q, opt)
     const isPartialQuery = !!q._selectedFieldNames
@@ -243,13 +244,13 @@ export class CommonDao<
   }
 
   async runQueryCount(q: DBQuery<DBM>, opt: CommonDaoReadOptions = {}): Promise<number> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     return await this.cfg.db.runQueryCount(q, opt)
   }
 
   streamQueryAsDBM(q: DBQuery<DBM>, opt: CommonDaoStreamOptions<DBM> = {}): Pipeline<DBM> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     let pipeline = this.cfg.db.streamQuery<DBM>(q, opt)
 
@@ -267,7 +268,7 @@ export class CommonDao<
   }
 
   streamQuery(q: DBQuery<DBM>, opt: CommonDaoStreamOptions<BM> = {}): Pipeline<BM> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     let pipeline = this.cfg.db.streamQuery<DBM>(q, opt)
 
@@ -285,14 +286,14 @@ export class CommonDao<
   }
 
   async queryIds(q: DBQuery<DBM>, opt: CommonDaoReadOptions = {}): Promise<ID[]> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     const { rows } = await this.cfg.db.runQuery(q.select(['id']), opt)
     return rows.map(r => r.id as ID)
   }
 
   streamQueryIds(q: DBQuery<DBM>, opt: CommonDaoStreamOptions<ID> = {}): Pipeline<ID> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     opt.errorMode ||= ErrorMode.SUPPRESS
 
@@ -650,7 +651,7 @@ export class CommonDao<
     q: DBQuery<DBM>,
     opt: CommonDaoStreamDeleteOptions<DBM> = {},
   ): Promise<number> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
     this.requireWriteAccess()
     this.requireObjectMutability(opt)
     q.table = opt.table || q.table
@@ -691,6 +692,7 @@ export class CommonDao<
 
   async patchByIds(ids: ID[], patch: Partial<DBM>, opt: CommonDaoOptions = {}): Promise<number> {
     if (!ids.length) return 0
+    this.assertNotCompressed(Object.keys(patch), 'patchByIds')
     return await this.patchByQuery(this.query().filterIn('id', ids), patch, opt)
   }
 
@@ -699,7 +701,8 @@ export class CommonDao<
     patch: Partial<DBM>,
     opt: CommonDaoOptions = {},
   ): Promise<number> {
-    this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
+    this.validateQuery(q) // throws if query uses `excludeFromIndexes` property
+    this.assertNotCompressed(Object.keys(patch), 'patchByQuery')
     this.requireWriteAccess()
     this.requireObjectMutability(opt)
     q.table = opt.table || q.table
@@ -712,6 +715,7 @@ export class CommonDao<
    * @experimental
    */
   async increment(prop: keyof DBM, id: ID, by = 1, opt: CommonDaoOptions = {}): Promise<number> {
+    this.assertNotCompressed([prop], 'increment')
     this.requireWriteAccess()
     this.requireObjectMutability(opt)
     const { table } = this.cfg
@@ -731,6 +735,7 @@ export class CommonDao<
     incrementMap: StringMap<number>,
     opt: CommonDaoOptions = {},
   ): Promise<StringMap<number>> {
+    this.assertNotCompressed([prop], 'incrementBatch')
     this.requireWriteAccess()
     this.requireObjectMutability(opt)
     const { table } = this.cfg
@@ -875,6 +880,19 @@ export class CommonDao<
     const properties = JSON.parse(bufferString)
     dbm.__compressed = undefined
     Object.assign(dbm, properties)
+  }
+
+  private assertNotCompressed(keys: (keyof DBM | string)[] | undefined, op: string): void {
+    if (!keys) return
+
+    const compressKeys = this.cfg.compress?.keys
+    if (!compressKeys?.length) return
+    for (const k of keys) {
+      _assert(
+        k !== '__compressed' && !compressKeys.includes(k as keyof DBM),
+        `${op} on ${this.cfg.table} cannot touch compressed property: ${k as string}`,
+      )
+    }
   }
 
   anyToDBM(dbm: undefined, opt?: CommonDaoOptions): null
@@ -1210,6 +1228,29 @@ export class CommonDao<
     _assert(!this.cfg.immutable || opt.allowMutability, DBLibError.OBJECT_IS_IMMUTABLE, {
       table: this.cfg.table,
     })
+  }
+
+  private validateQuery(q: DBQuery<DBM>): void {
+    this.validateQueryIndexes(q)
+    this.validateQueryCompression(q)
+  }
+
+  private validateQueryCompression(q: DBQuery<DBM>): void {
+    const { _filters, _orders, _selectedFieldNames } = q
+
+    if (_filters) {
+      const columnNames = _filters.map(cfg => cfg.name)
+      this.assertNotCompressed(columnNames, 'filter')
+    }
+
+    if (_orders) {
+      const columnNames = _orders.map(cfg => cfg.name)
+      this.assertNotCompressed(columnNames, 'order')
+    }
+
+    if (_selectedFieldNames) {
+      this.assertNotCompressed(_selectedFieldNames, 'select')
+    }
   }
 
   /**


### PR DESCRIPTION
In this PR, I add a verification (similar to `validateQueryIndexes`) to ensure that we are not using compressed properties in DAO functions that don't support it. One notable example: `patchByIds`.