### PR TITLE
feat(dev-lib): enable no-nested-ternary oxlint rule

### DIFF
--- a/packages/backend-lib/src/server/asyncLocalStorageMiddleware.ts
+++ b/packages/backend-lib/src/server/asyncLocalStorageMiddleware.ts
@@ -37,10 +37,11 @@ export function getRequest(): BackendRequest | undefined {
  * @experimental
  */
 export function getRequestLogger(): CommonLogger {
-  return (
-    storage().getStore()?.req ||
-    (isGAE || isCloudRun ? gcpStructuredLogger : isCI ? ciLogger : devLogger)
-  )
+  const req = storage().getStore()?.req
+  if (req) return req
+  if (isGAE || isCloudRun) return gcpStructuredLogger
+  if (isCI) return ciLogger
+  return devLogger
 }
 
 /**

--- a/packages/datastore-lib/src/datastore.db.ts
+++ b/packages/datastore-lib/src/datastore.db.ts
@@ -721,5 +721,7 @@ export class DatastoreDBTransaction implements DBTransaction {
 }
 
 function idComparator<T extends ObjectWithId>(a: T, b: T): number {
-  return a.id > b.id ? 1 : a.id < b.id ? -1 : 0
+  if (a.id > b.id) return 1
+  if (a.id < b.id) return -1
+  return 0
 }

--- a/packages/dev-lib/cfg/oxlint.config.js
+++ b/packages/dev-lib/cfg/oxlint.config.js
@@ -88,6 +88,7 @@ export const sharedConfig = {
     'no-disabled-tests': 0,
     'vitest/no-disabled-tests': 0,
     'no-useless-assignment': 0, // buggy, gives false positives
+    'no-nested-ternary': 2,
     'object-shorthand': 2,
     'valid-expect': 0,
     'valid-title': 0,

--- a/packages/js-lib/src/datetime/localDate.ts
+++ b/packages/js-lib/src/datetime/localDate.ts
@@ -40,7 +40,9 @@ export class LocalDate {
   ) {}
 
   get(unit: LocalDateUnitStrict): number {
-    return unit === 'year' ? this.year : unit === 'month' ? this.month : this.day
+    if (unit === 'year') return this.year
+    if (unit === 'month') return this.month
+    return this.day
   }
 
   set(unit: LocalDateUnitStrict, v: number, opt: MutateOptions = {}): LocalDate {

--- a/packages/js-lib/src/number/number.util.ts
+++ b/packages/js-lib/src/number/number.util.ts
@@ -50,7 +50,9 @@ export function _isBetween<T extends number | string>(
 }
 
 export function _clamp(x: number, minIncl: number, maxIncl: number): number {
-  return x <= minIncl ? minIncl : x >= maxIncl ? maxIncl : x
+  if (x <= minIncl) return minIncl
+  if (x >= maxIncl) return maxIncl
+  return x
 }
 
 /**

--- a/packages/js-lib/src/qr/qr.ts
+++ b/packages/js-lib/src/qr/qr.ts
@@ -684,8 +684,9 @@ function getLengthInBits(mode: number, type: number): number {
   if (type < 1 || type > 40) throw new Error(`qr: bad type number: ${type}`)
   const bits = LENGTH_BITS[mode]
   if (!bits) throw new Error(`qr: bad mode: ${mode}`)
-  const range = type < 10 ? 0 : type < 27 ? 1 : 2
-  return bits[range]
+  if (type < 10) return bits[0]
+  if (type < 27) return bits[1]
+  return bits[2]
 }
 
 // --- Reed-Solomon polynomials over GF(256) ---------------------------------

--- a/packages/js-lib/src/semver.ts
+++ b/packages/js-lib/src/semver.ts
@@ -171,5 +171,7 @@ export function _quickSemverCompare(a: string, b: string): -1 | 0 | 1 {
   const s2 = _range(3)
     .map(i => (t2[i] || '').padStart(5))
     .join('')
-  return s1 < s2 ? -1 : s1 > s2 ? 1 : 0
+  if (s1 < s2) return -1
+  if (s1 > s2) return 1
+  return 0
 }

--- a/packages/js-lib/src/string/leven.ts
+++ b/packages/js-lib/src/string/leven.ts
@@ -76,14 +76,12 @@ export function _leven(first: string, second: string, limit?: number): number {
       temporary2 = bCharacterCode === characterCodeCache[index] ? temporary : temporary + 1
       temporary = array[index]!
 
-      result = array[index] =
-        temporary > result
-          ? temporary2 > result
-            ? result + 1
-            : temporary2
-          : temporary2 > temporary
-            ? temporary + 1
-            : temporary2
+      if (temporary > result) {
+        result = temporary2 > result ? result + 1 : temporary2
+      } else {
+        result = temporary2 > temporary ? temporary + 1 : temporary2
+      }
+      array[index] = result
     }
   }
 

--- a/packages/nodejs-lib/src/zip/zipInternal.ts
+++ b/packages/nodejs-lib/src/zip/zipInternal.ts
@@ -76,8 +76,12 @@ const MAX_DOS_DATE = new Date(2107, 11, 31, 23, 59, 58)
  * timestamp is rendered in the local timezone. Out-of-range dates are clamped to 1980-2107.
  */
 export function unixToDosDateTime(ts: UnixTimestamp): { date: number; time: number } {
-  const jsDate = new Date(ts * 1000)
-  const d = jsDate < MIN_DOS_DATE ? MIN_DOS_DATE : jsDate > MAX_DOS_DATE ? MAX_DOS_DATE : jsDate
+  let d = new Date(ts * 1000)
+  if (d < MIN_DOS_DATE) {
+    d = MIN_DOS_DATE
+  } else if (d > MAX_DOS_DATE) {
+    d = MAX_DOS_DATE
+  }
 
   const date =
     (d.getDate() & 0x1f) | // 1-31


### PR DESCRIPTION
Turns on the `no-nested-ternary` oxlint rule in the shared config.

Stacked on #153, which clears the existing violations here; GitHub will retarget this to `main` once that merges. Consumers should be clean before picking up the new dev-lib version.